### PR TITLE
feature: --filter flag

### DIFF
--- a/bin/puny
+++ b/bin/puny
@@ -16,16 +16,19 @@ define('PUNY_VERSION', '0.1.0');
         require_once $localPath;
     }
 
+    $puny = Puny::instance();
+
     if (count($argv) >= 2) {
         [, $folder] = $argv;
+
+        $puny->setRoot($folder);
+
+        if (in_array('--filter', $argv)) {
+            $puny->filterBy($argv[array_search('--filter', $argv) + 1]);
+        }
     } else {
-        $folder = getcwd().'/tests';
+        $puny->setRoot(getcwd() . '/tests');
     }
 
-    if (! is_dir($folder)) {
-        Console::error("Could not find the specified folder, {$folder}.");
-    }
-
-    Puny::instance()
-        ->run($folder);
+    $puny->run();
 })();


### PR DESCRIPTION
Closes #15.

One thing I want to do **before** merging is fix the argument parsing. Currently you _have_ to pass the tests folder becausee I'm assuming it's the 2nd item in th `$argv` array.

Could probably do something smarter or just use `getopt`, even if it is a horrible function.