### PR TITLE
Feature: equality helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ Make unit testing in PHP simpler again. 👌
 
 ## Table of Contents
 
-* [Installation](#installation)
-* [Usage](#usage)
-    * [Writing your first test](#writing-your-first-test)
-    * [Checking things are okay](#checking-things-are-okay)
-    * [Skipping tests](#skipping-tests)
-    * [Spying on functions](#spying-on-functions)
-* [Why does Puny exist?](#why-does-puny-exist)
+- [Puny](#puny)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Writing your first test](#writing-your-first-test)
+    - [Checking things are okay](#checking-things-are-okay)
+    - [Comparing equality with eq](#comparing-equality-with-eq)
+    - [Skipping tests](#skipping-tests)
+    - [Spying on functions](#spying-on-functions)
+  - [Why does Puny exist?](#why-does-puny-exist)
 
 ## Installation
 
@@ -65,6 +68,18 @@ You can use the `ok` function to check whether or not something correct (okay). 
 
 ```php
 ok(1 + 2 === 3, 'math is good');
+```
+
+### Comparing equality with eq
+
+You can use the `eq` function to strictly compare if two values are equal. The first argument is your expected value. The second is your actual value. But they are interchangable and just a suggestion. The return value is a `bool` result of the comparison check.
+
+> Can be used is in conjunction with `ok` for a more descriptive equality check.
+
+```php
+eq(3, 1 + 2);
+
+ok(eq(3, 1 + 2), 'math is good');
 ```
 
 ### Skipping tests

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Make unit testing in PHP simpler again. 👌
   - [Usage](#usage)
     - [Writing your first test](#writing-your-first-test)
     - [Checking things are okay](#checking-things-are-okay)
-    - [Comparing equality with eq](#comparing-equality-with-eq)
+    - [Checking equality with eq](#checking-equality-with-eq)
     - [Skipping tests](#skipping-tests)
     - [Spying on functions](#spying-on-functions)
   - [Why does Puny exist?](#why-does-puny-exist)
@@ -70,7 +70,7 @@ You can use the `ok` function to check whether or not something correct (okay). 
 ok(1 + 2 === 3, 'math is good');
 ```
 
-### Comparing equality with eq
+### Checking equality with eq
 
 You can use the `eq` function to check if two values are **strictly** equal. The first argument is your expected value. The second is your actual value. But they are interchangable and just a suggestion. The return value is a `bool` result of the comparison check.
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,10 @@ ok(1 + 2 === 3, 'math is good');
 
 ### Checking equality with eq
 
-You can use the `eq` function to check if two values are **strictly** equal. The first argument is your expected value. The second is your actual value. But they are interchangable and just a suggestion. The return value is a `bool` result of the comparison check.
-
-> Can be used is in conjunction with `ok` for a more descriptive equality check.
+You can use the `eq` function to check if two values are **strictly** equal. The first argument is your expected value. The second is your actual value. But they are interchangable and just a suggestion. The third argument is the specific scenario you are testing. The return value is a `bool` result of the comparison check.
 
 ```php
-eq(3, 1 + 2);
-
-ok(eq(3, 1 + 2), 'math is good');
+eq(3, 1 + 2, 'math is good');
 ```
 
 ### Skipping tests

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ ok(1 + 2 === 3, 'math is good');
 
 ### Comparing equality with eq
 
-You can use the `eq` function to strictly compare if two values are equal. The first argument is your expected value. The second is your actual value. But they are interchangable and just a suggestion. The return value is a `bool` result of the comparison check.
+You can use the `eq` function to check if two values are **strictly** equal. The first argument is your expected value. The second is your actual value. But they are interchangable and just a suggestion. The return value is a `bool` result of the comparison check.
 
 > Can be used is in conjunction with `ok` for a more descriptive equality check.
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -26,6 +26,28 @@ function spy(callable $callback) {
     return new Spy($callback);
 }
 
+/**
+ * @param mixed $expected
+ * @param mixed $actual
+ *
+ * @return bool
+ */
+function eq($expected, $actual) {
+    if ($expected === $actual) {
+        return true;
+    }
+
+    if (is_callable($expected)) {
+        $expected = (\Closure::fromCallable($expected))();
+    }
+
+    if (is_callable($actual)) {
+        $actual = (\Closure::fromCallable($actual))();
+    }
+
+    return $expected == $actual;
+}
+
 function skip() {
     throw new SkippedException;
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -33,19 +33,10 @@ function spy(callable $callback) {
  * @return bool
  */
 function eq($expected, $actual) {
-    if ($expected === $actual) {
-        return true;
-    }
+    $expected = is_callable($expected) ? $expected() : $expected;
+    $actual = is_callable($actual) ? $actual() : $actual;
 
-    if (is_callable($expected)) {
-        $expected = (\Closure::fromCallable($expected))();
-    }
-
-    if (is_callable($actual)) {
-        $actual = (\Closure::fromCallable($actual))();
-    }
-
-    return $expected == $actual;
+    return $expected === $actual;
 }
 
 function skip() {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -27,16 +27,17 @@ function spy(callable $callback) {
 }
 
 /**
- * @param mixed $expected
- * @param mixed $actual
+ * @param mixed  $expected
+ * @param mixed  $actual
+ * @param string $id
  *
  * @return bool
  */
-function eq($expected, $actual) {
+function eq($expected, $actual, string $id) {
     $expected = is_callable($expected) ? $expected() : $expected;
     $actual = is_callable($actual) ? $actual() : $actual;
 
-    return $expected === $actual;
+    return ok($expected === $actual, $id);
 }
 
 function skip() {

--- a/tests/eq.php
+++ b/tests/eq.php
@@ -15,5 +15,5 @@ test('The `eq` function works with callable', function () {
 });
 
 test('The `eq` function works with function', function () {
-    ok(eq(ceil(1.2), 2), '`eq` works.');
+    ok(eq(ceil(1.2), 2.0), '`eq` works.');
 });

--- a/tests/eq.php
+++ b/tests/eq.php
@@ -3,17 +3,17 @@
 use function Puny\{test, eq, ok};
 
 test('The `eq` function works', function () {
-    ok(eq(2, 1 + 1), '`eq` works.');
+    eq(2, 1 + 1, '`eq` works.');
 });
 
 test('The `eq` function works with array', function () {
-    ok(eq([2], [1 + 1]), '`eq` works.');
+    eq([2], [1 + 1], '`eq` works.');
 });
 
 test('The `eq` function works with callable', function () {
-    ok(eq(fn () => 2, fn () => 1 + 1), '`eq` works.');
+    eq(fn () => 2, fn () => 1 + 1, '`eq` works.');
 });
 
 test('The `eq` function works with function', function () {
-    ok(eq(ceil(1.2), 2.0), '`eq` works.');
+    eq(ceil(1.2), 2.0, '`eq` works.');
 });

--- a/tests/eq.php
+++ b/tests/eq.php
@@ -1,6 +1,6 @@
 <?php
 
-use function Puny\{test, eq, ok};
+use function Puny\{test, eq};
 
 test('The `eq` function works', function () {
     eq(2, 1 + 1, '`eq` works.');

--- a/tests/eq.php
+++ b/tests/eq.php
@@ -1,0 +1,19 @@
+<?php
+
+use function Puny\{test, eq, ok};
+
+test('The `eq` function works', function () {
+    ok(eq(2, 1 + 1), '`eq` works.');
+});
+
+test('The `eq` function works with array', function () {
+    ok(eq([2], [1 + 1]), '`eq` works.');
+});
+
+test('The `eq` function works with callable', function () {
+    ok(eq(fn () => 2, fn () => 1 + 1), '`eq` works.');
+});
+
+test('The `eq` function works with function', function () {
+    ok(eq(ceil(1.2), 2), '`eq` works.');
+});


### PR DESCRIPTION
This PR adds a rudimentary `eq` function for checking equality. It was talked about in the "minimal testing" blog post that inspired Puny, but it wasn't in the framework. So I decided to create a simple `eq` function.

Had to add a phpdoc for the `eq()` since `mixed` type-hinting isn't supported in 7.4 sadly.