### PR TITLE
feature: execution time

### DIFF
--- a/src/Puny.php
+++ b/src/Puny.php
@@ -70,7 +70,7 @@ final class Puny
         $end = microtime(true);
 
         Console::write(sprintf(
-            "%s tests run. %s passed. %s failed. %s skipped. %02.2f ms",
+            "%s tests run. %s passed. %s failed. %s skipped. %02.2f s",
             count(static::$tests),
             count(static::$tests) - $this->failed - $this->skipped,
             $this->failed,

--- a/src/Puny.php
+++ b/src/Puny.php
@@ -38,6 +38,8 @@ final class Puny
             exit(1);
         }
 
+        $start = microtime(true);
+
         self::requireIfReadable($this->root.'/bootstrap.php');
         self::includeTestFiles($this->root);
 
@@ -65,12 +67,15 @@ final class Puny
 
         self::requireIfReadable($this->root.'/tidy-up.php');
 
+        $end = microtime(true);
+
         Console::write(sprintf(
-            "%s tests run. %s passed. %s failed. %s skipped.",
+            "%s tests run. %s passed. %s failed. %s skipped. %02.2f ms",
             count(static::$tests),
             count(static::$tests) - $this->failed - $this->skipped,
             $this->failed,
             $this->skipped,
+            $end - $start
         ));
     }
 

--- a/src/Puny.php
+++ b/src/Puny.php
@@ -67,8 +67,6 @@ final class Puny
 
         self::requireIfReadable($this->root.'/tidy-up.php');
 
-        $end = microtime(true);
-
         Console::write(sprintf(
             "%s tests run. %s passed. %s failed. %s skipped. %02.2f s",
             count(static::$tests),

--- a/src/Puny.php
+++ b/src/Puny.php
@@ -75,7 +75,7 @@ final class Puny
             count(static::$tests) - $this->failed - $this->skipped,
             $this->failed,
             $this->skipped,
-            $end - $start
+            microtime(true) - $start
         ));
     }
 

--- a/tests/tidy-up.php
+++ b/tests/tidy-up.php
@@ -2,4 +2,6 @@
 
 use Puny\Support\Console;
 
+sleep(1);
+
 Console::info("\xE2\x9C\x94 The `tidy-up.php` file is executed");


### PR DESCRIPTION
This PR adds the execution time of Puny in milliseconds to the end of the output - see screenshot below.

For now, it includes the whole execution in the calculation no just the test phase. The bootstrap phase, tests, and the teardown phase is added to get a proper representation of the execution time.

Potential issues will be longer tests that run in minutes or hours not being formatted in a nicer way, e.g `1 min 2 sec`.

Closes #18 

### Screenshot of test with new output.

![Screen shot of test running with included execution time](https://user-images.githubusercontent.com/2221746/105983921-b487e600-6099-11eb-9268-b38474f99e20.png)