### PR TITLE
fix: version 0.2.0

### DIFF
--- a/bin/puny
+++ b/bin/puny
@@ -4,7 +4,7 @@
 use Puny\Puny;
 use Puny\Support\Console;
 
-define('PUNY_VERSION', '0.2.0');
+define('PUNY_VERSION', '0.2.1');
 
 (static function () use ($argv) {
     $vendorPath = dirname(__DIR__, 4) . '/vendor/autoload.php';

--- a/bin/puny
+++ b/bin/puny
@@ -4,7 +4,7 @@
 use Puny\Puny;
 use Puny\Support\Console;
 
-define('PUNY_VERSION', '0.1.0');
+define('PUNY_VERSION', '0.2.0');
 
 (static function () use ($argv) {
     $vendorPath = dirname(__DIR__, 4) . '/vendor/autoload.php';


### PR DESCRIPTION
Not sure if a version can be switched with another but a version bump was forgotten in the `bin/puny`.

It displays `0.1.0` whilst the release is `0.2.0`, can this be added to `0.2.0` or does it have to be bumped to `0.2.1`? 🤔